### PR TITLE
Adding @ResponseStatus partial support

### DIFF
--- a/spring-wadl-generator/src/main/java/com/autentia/web/rest/wadl/builder/ResponseBuilder.java
+++ b/spring-wadl-generator/src/main/java/com/autentia/web/rest/wadl/builder/ResponseBuilder.java
@@ -16,14 +16,18 @@
 package com.autentia.web.rest.wadl.builder;
 
 import net.java.dev.wadl._2009._02.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 
 class ResponseBuilder {
 
     private static final long OK = 200L;
-
+    private static final Logger logger = LoggerFactory.getLogger(ResponseBuilder.class);
     private final RepresentationBuilder representationBuilder = new RepresentationBuilder();
 
     Collection<Response> build(MethodContext ctx) {
@@ -32,8 +36,15 @@ class ResponseBuilder {
          * By now just one 'response' element is returned, but the method returns a collection
          * because the specification supports several elements of this kind.
          */
+        long status = OK;
+        for (Annotation a : ctx.getJavaMethod().getDeclaredAnnotations()) {
+            if ("org.springframework.web.bind.annotation.ResponseStatus".equalsIgnoreCase(a.annotationType().getCanonicalName())) {
+                status = ((ResponseStatus) a).value().value();
+                logger.debug("Set Response status to {0}", status);
+            }
+        }
         responses.add(new Response()
-                .withStatus(OK)
+                .withStatus(status)
                 .withRepresentation(representationBuilder.build(ctx)));
         return responses;
     }

--- a/spring-wadl-showcase/src/main/java/com/autentia/showcase/web/rest/contacts/AddressBookController.java
+++ b/spring-wadl-showcase/src/main/java/com/autentia/showcase/web/rest/contacts/AddressBookController.java
@@ -20,12 +20,9 @@ import com.autentia.showcase.contacts.Contact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
 
@@ -68,6 +65,7 @@ public class AddressBookController {
 
     @RequestMapping(value = "/contacts", method = RequestMethod.POST, consumes = AppRestConstants.JSON)
     @ResponseBody
+    @ResponseStatus(HttpStatus.CREATED)
     public void addContact() {
 //    public void addContact(@RequestBody Contact contact) {
 //        addressBook.save(contact);


### PR DESCRIPTION
@ResponseStatus set the http status reponse. 
example
@RequestMapping(value = "/contacts", method = RequestMethod.POST, consumes = AppRestConstants.JSON)
    @ResponseBody
    @ResponseStatus(HttpStatus.CREATED)
    public void addContact() {
        addressBook.save(new Contact());
    }
=> WADL result
<resource path="/rest/contacts">
<method id="addContact" name="POST">
<response status="201"/>
</method>
</resource>

Actually the http status is force to 200 (OK). 

Correction : 
If @ResponseStatus exists used the value is used
else 200 status is used. 
